### PR TITLE
feat: Add OpenTelemetry instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # shiptrack
+
+## Observability
+
+This application is instrumented using OpenTelemetry for distributed tracing. This allows you to gain insights into the application's performance and behavior, especially in a microservices environment.
+
+### Configuration
+
+The following environment variables can be used to configure OpenTelemetry:
+
+*   `OTEL_SERVICE_NAME`: Sets the service name for the application (e.g., `shipping-app`). This helps in identifying the application within your tracing backend.
+*   `OTEL_EXPORTER_OTLP_ENDPOINT`: Specifies the OTLP (OpenTelemetry Protocol) endpoint where traces should be sent (e.g., `http://localhost:4318/v1/traces`). This is the address of your OpenTelemetry collector or tracing backend.

--- a/app.py
+++ b/app.py
@@ -1,9 +1,40 @@
 from flask import Flask, jsonify, abort, request
 import requests, time
 from data_model import Package
-from connect_connector import SessionMaker
+from connect_connector import SessionMaker, engine # Import engine
+import os # For environment variables
+
+# OpenTelemetry imports
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.instrumentation.flask import FlaskInstrumentor
+from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
+from opentelemetry.instrumentation.requests import RequestsInstrumentor
 
 app = Flask(__name__)
+
+# OpenTelemetry Setup
+service_name = os.getenv("OTEL_SERVICE_NAME", "shipping-app")
+resource = Resource(attributes={
+    "service.name": service_name
+})
+otlp_exporter = OTLPSpanExporter(endpoint=os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318/v1/traces"))
+tracer_provider = TracerProvider(resource=resource)
+span_processor = BatchSpanProcessor(otlp_exporter)
+tracer_provider.add_span_processor(span_processor)
+trace.set_tracer_provider(tracer_provider)
+
+# Instrument Flask app
+FlaskInstrumentor().instrument_app(app)
+
+# Instrument SQLAlchemy
+SQLAlchemyInstrumentor().instrument(engine=engine)
+
+# Instrument requests
+RequestsInstrumentor().instrument()
 
 @app.route('/discovery', methods=['GET'])
 def discovery():

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,9 @@ psycopg2-binary
 requests==2.28.1
 CORS
 flask_cors
+opentelemetry-api
+opentelemetry-sdk
+opentelemetry-exporter-otlp-proto-http
+opentelemetry-instrumentation-flask
+opentelemetry-instrumentation-sqlalchemy
+opentelemetry-instrumentation-requests


### PR DESCRIPTION
Integrates OpenTelemetry into the Flask application for distributed tracing.

Key changes:
- Added required OpenTelemetry libraries to `requirements.txt`.
- Configured OpenTelemetry SDK in `app.py`:
    - Initializes a TracerProvider, OTLPSpanExporter (HTTP), and BatchSpanProcessor.
    - Service name is configurable via `OTEL_SERVICE_NAME`.
    - OTLP endpoint is configurable via `OTEL_EXPORTER_OTLP_ENDPOINT`.
- Instrumented Flask, SQLAlchemy, and Requests to automatically generate spans.
- Updated `README.md` with a new "Observability" section detailing the OpenTelemetry setup and required environment variables.

This allows the application to export trace data to an OpenTelemetry-compatible backend, providing insights into request flows and performance.